### PR TITLE
Added "underscore" and "undescore.string" to dependecies

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -41,7 +41,9 @@
         "mongoose-timestamp": "~0.2.0",
         "mongoose-validator": "~0.2.2",
         "newrelic": "latest",
-        "forever": "~0.10.11"
+        "forever": "~0.10.11",
+        "underscore": "~1.8.3",
+        "underscore.string": "~3.0.3"
     },
     "devDependencies": {
         "mocha": "~1.10.0",


### PR DESCRIPTION
Loader requiring "underscore" and "underscore.string" which are not included in package.json
https://github.com/chrisenytc/generator-demi/blob/master/app/templates/lib/loader.js#L19-20

So after fresh install "npm start" will cause errors:
Error: Cannot find module 'underscore'
Error: Cannot find module 'underscore.string'
